### PR TITLE
Add pass through entropy to guest operating system

### DIFF
--- a/constants.go
+++ b/constants.go
@@ -48,6 +48,13 @@ const (
       <source network='{{.Network}}'/>
       <model type='virtio'/>
     </interface>
+    <console type='pty'></console>
+    <channel type='pty'>
+      <target type='virtio' name='org.qemu.guest_agent.0'/>
+    </channel>
+    <rng model='virtio'>
+      <backend model='random'>/dev/random</backend>
+    </rng>
   </devices>
 </domain>`
 )


### PR DESCRIPTION
CoreOS required the `random: crng init done` and this will help to provide it fast.
Also we added the console `tty` so if by any chance vm doesn't come up we can debug
using `virsh console <vm_name>`.

- https://libvirt.org/formatdomain.html#elementsRng