### PR TITLE
Issue #15 Use status file to get the IP and remove to look for leasefile

### DIFF
--- a/libvirt.go
+++ b/libvirt.go
@@ -530,6 +530,13 @@ func (d *Driver) getIPByMacFromSettings(mac string) (string, error) {
 
 func (d *Driver) GetIP() (string, error) {
 	log.Debugf("GetIP called for %s", d.MachineName)
+	s, err := d.GetState()
+	if err != nil {
+		return "", fmt.Errorf("%v : machine in unknown state", err)
+	}
+	if s != state.Running {
+		return "", errors.New("host is not running")
+	}
 	mac, err := d.getMAC()
 	if err != nil {
 		return "", err

--- a/libvirt.go
+++ b/libvirt.go
@@ -316,20 +316,29 @@ func (d *Driver) Start() error {
 	// They wont start immediately
 	time.Sleep(5 * time.Second)
 
-	for i := 0; i < 90; i++ {
-		time.Sleep(time.Second)
+	for i := 0; i < 40; i++ {
 		ip, err := d.GetIP()
 		if err != nil {
 			return fmt.Errorf("%v: getting ip during machine start", err)
 		}
+
+		if ip == "" {
+			log.Debugf("Waiting for machine to come up %d/%d", i, 40)
+			time.Sleep(3 * time.Second)
+			continue
+		}
+
 		if ip != "" {
-			// Add a second to let things settle
-			time.Sleep(time.Second)
-			return nil
+			log.Infof("Found IP for machine: %s", ip)
+			d.IPAddress = ip
+			break
 		}
 		log.Debugf("Waiting for the VM to come up... %d", i)
 	}
-	log.Warnf("Unable to determine VM's IP address, did it fail to boot?")
+
+	if d.IPAddress == "" {
+		log.Warnf("Unable to determine VM's IP address, did it fail to boot?")
+	}
 	return nil
 }
 

--- a/libvirt.go
+++ b/libvirt.go
@@ -318,7 +318,10 @@ func (d *Driver) Start() error {
 
 	for i := 0; i < 90; i++ {
 		time.Sleep(time.Second)
-		ip, _ := d.GetIP()
+		ip, err := d.GetIP()
+		if err != nil {
+			return fmt.Errorf("%v: getting ip during machine start", err)
+		}
 		if ip != "" {
 			// Add a second to let things settle
 			time.Sleep(time.Second)


### PR DESCRIPTION
We don't need to have now lookupIPFromLeasesFile since all the major
distro have libvirt > 2.0.0 and that was for the 1.2.6

Also we are adding 120sec wait time in 40 loop in 3 sec interval then
default one.