### PR TITLE
Don't unmarshal empty status file.

### DIFF
--- a/libvirt.go
+++ b/libvirt.go
@@ -316,14 +316,14 @@ func (d *Driver) Start() error {
 	// They wont start immediately
 	time.Sleep(5 * time.Second)
 
-	for i := 0; i < 40; i++ {
+	for i := 0; i < 60; i++ {
 		ip, err := d.GetIP()
 		if err != nil {
 			return fmt.Errorf("%v: getting ip during machine start", err)
 		}
 
 		if ip == "" {
-			log.Debugf("Waiting for machine to come up %d/%d", i, 40)
+			log.Debugf("Waiting for machine to come up %d/%d", i, 60)
 			time.Sleep(3 * time.Second)
 			continue
 		}

--- a/libvirt.go
+++ b/libvirt.go
@@ -521,6 +521,11 @@ func (d *Driver) getIPByMacFromSettings(mac string) (string, error) {
 	}
 	var s []Lease
 
+	// In case of status file is empty then don't try to unmarshal data
+	if len(data) == 0 {
+		return "", nil
+	}
+
 	err = json.Unmarshal(data, &s)
 	if err != nil {
 		log.Warnf("Failed to decode dnsmasq lease status: %s", err)


### PR DESCRIPTION
Currently we are trying to unmarshal the status file which can be empty
if within 5 sec once instance is in running state but not able to update
all the resources here it is network one which located to the libvirt
dir `/var/lib/libvirt/dnsmasq/crc.status`. What we should do is check
if that file is empty and do nothing until the update happen to it.