### PR TITLE
Issue #22: Update to latest machine code

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/code-ready/machine-driver-libvirt
 
 require (
-	github.com/code-ready/machine v0.7.1-0.20190501073902-87391ca2ceed
+	github.com/code-ready/machine v0.0.0-20190731093717-b6d974ad44d0
 	github.com/libvirt/libvirt-go v3.4.0+incompatible
 )

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,7 @@
 github.com/bugsnag/bugsnag-go v1.5.1/go.mod h1:2oa8nejYd4cQ/b0hMIopN0lCRxU0bueqREvZLWFrtK8=
 github.com/bugsnag/panicwrap v1.2.0/go.mod h1:D/8v3kj0zr8ZAKg1AQ6crr+5VwKN5eIywRkfhyM/+dE=
+github.com/code-ready/machine v0.0.0-20190731093717-b6d974ad44d0 h1:036aGx7BK4a7FtdBUprV64az1cY2cQC4PrhMU63Wzxs=
+github.com/code-ready/machine v0.0.0-20190731093717-b6d974ad44d0/go.mod h1:2Kr23hBx5xUHetynE+4hFBwn7Xkx5qoF0SY1FzmLz74=
 github.com/code-ready/machine v0.7.1-0.20190501073902-87391ca2ceed h1:ofkhUp+w8H0H0yg31HeHAUrTILg/LsXSKYUXejyhqaw=
 github.com/code-ready/machine v0.7.1-0.20190501073902-87391ca2ceed/go.mod h1:2Kr23hBx5xUHetynE+4hFBwn7Xkx5qoF0SY1FzmLz74=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=

--- a/libvirt.go
+++ b/libvirt.go
@@ -16,10 +16,10 @@ import (
 	"github.com/libvirt/libvirt-go"
 
 	// Machine-drivers
-	"github.com/code-ready/machine/libmachine/mcnutils"
 	"github.com/code-ready/machine/libmachine/drivers"
 	"github.com/code-ready/machine/libmachine/log"
 	"github.com/code-ready/machine/libmachine/mcnflag"
+	"github.com/code-ready/machine/libmachine/mcnutils"
 	"github.com/code-ready/machine/libmachine/state"
 )
 
@@ -238,7 +238,7 @@ func (d *Driver) PreCreateCheck() error {
 }
 
 func (d *Driver) Create() error {
-	b2dutils := mcnutils.NewB2dUtils(d.StorePath)
+	b2dutils := mcnutils.NewB2dUtils(d.StorePath, "")
 	if err := b2dutils.CopyDiskToMachineDir(d.DiskPathURL, d.MachineName); err != nil {
 		return err
 	}


### PR DESCRIPTION
There was an API change in mcnutils.NewB2dUtils

This resolves https://github.com/code-ready/machine-driver-libvirt/issues/22