### PR TITLE
Issue #22: Adjust disk image name

### DIFF
--- a/libvirt.go
+++ b/libvirt.go
@@ -238,7 +238,7 @@ func (d *Driver) PreCreateCheck() error {
 }
 
 func (d *Driver) Create() error {
-	b2dutils := mcnutils.NewB2dUtils(d.StorePath, "")
+	b2dutils := mcnutils.NewB2dUtils(d.StorePath, "crc")
 	if err := b2dutils.CopyDiskToMachineDir(d.DiskPathURL, d.MachineName); err != nil {
 		return err
 	}


### PR DESCRIPTION
crc expects the libvirt disk image to be named 'crc', but with the
libmachine go module update, it now defaults to naming it 'crc.disk'.
This commit specifies an explicit name rather than relying on the
default name to get the image filename crc expects.

This resolves https://github.com/code-ready/machine-driver-libvirt/issues/22