### PR TITLE
Issue #29: validateVMRef: Return error when the VM does not exist

### DIFF
--- a/libvirt.go
+++ b/libvirt.go
@@ -437,6 +437,7 @@ func (d *Driver) validateVMRef() error {
 		vm, err := conn.LookupDomainByName(d.MachineName)
 		if err != nil {
 			log.Warnf("Failed to fetch machine")
+			return fmt.Errorf("Failed to fetch machine '%s'", d.MachineName)
 		} else {
 			d.VM = vm
 			d.vmLoaded = true


### PR DESCRIPTION
The code expects that when validateVMRef is successful, domain.VM is
valid, so we have to return an error when domain.VM could not be set
because a domain with that name does not exist.

This fixes https://github.com/code-ready/machine-driver-libvirt/issues/29