### PR TITLE
Add required go version to modules file

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,3 +4,5 @@ require (
 	github.com/code-ready/machine v0.0.0-20190904103148-0fde37b5d95b
 	github.com/libvirt/libvirt-go v3.4.0+incompatible
 )
+
+go 1.12


### PR DESCRIPTION
This is so that go 1.13 stops modifying the file to add version info.