### PR TITLE
Disable rdrand policy from vm domain

### DIFF
--- a/constants.go
+++ b/constants.go
@@ -19,7 +19,9 @@ const (
   <memory unit='MB'>{{ .Memory }}</memory>
   <vcpu placement='static'>{{ .CPU }}</vcpu>
   <features><acpi/><apic/><pae/></features>
-  <cpu mode='host-passthrough'></cpu>
+  <cpu mode='host-passthrough'>
+    <feature policy="disable" name="rdrand"/>
+  </cpu>
   <os>
     <type arch='x86_64'>hvm</type>
     <boot dev='hd'/>


### PR DESCRIPTION
The rdrand instruction is apparently broken on some motherboards
with the new Ryzen 3000 CPUs. This issue is supposed to be fixed by
BIOS update, but that's not available for all boards yet. As a workaround
we are disabling the rdrand policy so the VM can start on those systems.

- https://bugzilla.redhat.com/show_bug.cgi?id=1806532

Tested this with and without this patch on linux system.
```
$ cat /proc/cpuinfo | grep rdrand
flags		: fpu vme de pse tsc msr pae mce cx8 apic sep mtrr pge mca cmov pat pse36 clflush mmx fxsr sse sse2 ss syscall nx pdpe1gb rdtscp lm constant_tsc arch_perfmon rep_good nopl xtopology cpuid tsc_known_freq pni pclmulqdq vmx ssse3 fma cx16 pcid sse4_1 sse4_2 x2apic movbe popcnt tsc_deadline_timer aes xsave avx f16c rdrand hypervisor lahf_lm abm 3dnowprefetch cpuid_fault invpcid_single pti ssbd ibrs ibpb stibp tpr_shadow vnmi flexpriority ept vpid fsgsbase tsc_adjust bmi1 hle avx2 smep bmi2 erms invpcid rtm mpx rdseed adx smap clflushopt xsaveopt xsavec xgetbv1 xsaves arat umip md_clear arch_capabilities
```

```
$ cat /proc/cpuinfo | grep rdrand
[core@crc-brtfs-master-0 ~]$ 
```