### PR TITLE
Use urandom instead random for rng backend device

### DIFF
--- a/constants.go
+++ b/constants.go
@@ -55,7 +55,7 @@ const (
       <target type='virtio' name='org.qemu.guest_agent.0'/>
     </channel>
     <rng model='virtio'>
-      <backend model='random'>/dev/random</backend>
+      <backend model='random'>/dev/urandom</backend>
     </rng>
   </devices>
 </domain>`


### PR DESCRIPTION
As per upstream docs https://libvirt.org/formatdomain.html#elementsRng
it is recommended to use `/dev/urandom` instead of `/dev/random` to avoid some of
limitation which `/dev/random` have. Also installer uses `/dev/urandom` in the
instance template.

- https://bugzilla.redhat.com/show_bug.cgi?id=1803130