### PR TITLE
Add vsock support

### DIFF
--- a/constants.go
+++ b/constants.go
@@ -57,7 +57,9 @@ const (
     <rng model='virtio'>
       <backend model='random'>/dev/urandom</backend>
     </rng>
+    <vsock model='virtio'>
+      <cid auto='yes'/>
+    </vsock>
   </devices>
 </domain>`
 )
-


### PR DESCRIPTION
The cid address should be a parameter or auto. 

With a fixed cid, when I try to run 2 VMs, I obtain the error:

```
ERRO Error creating machine: Error creating the VM: Error creating machine: Error in driver during machine creation: virError(Code=38, Domain=0, Message='failed to set guest cid: Address already in use') 
``` 