### PR TITLE
Use libvirt.Driver definition from machine

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,7 +1,7 @@
 module github.com/code-ready/machine-driver-libvirt
 
 require (
-	github.com/code-ready/machine v0.0.0-20191122132905-c31e0b90623d
+	github.com/code-ready/machine v0.0.0-20200810103403-d2277fb226c4
 	github.com/libvirt/libvirt-go v3.4.0+incompatible
 )
 

--- a/go.sum
+++ b/go.sum
@@ -2,6 +2,10 @@ github.com/bugsnag/bugsnag-go v1.5.1/go.mod h1:2oa8nejYd4cQ/b0hMIopN0lCRxU0bueqR
 github.com/bugsnag/panicwrap v1.2.0/go.mod h1:D/8v3kj0zr8ZAKg1AQ6crr+5VwKN5eIywRkfhyM/+dE=
 github.com/code-ready/machine v0.0.0-20191122132905-c31e0b90623d h1:vBAkwlo8J/3BWQzTvGc7JFrqCMnRSKmcVnGYqGzGFpI=
 github.com/code-ready/machine v0.0.0-20191122132905-c31e0b90623d/go.mod h1:g30jKsf0FV9yJjsqZFAuFzVxwJE2h5cqDXSuMUV1G/U=
+github.com/code-ready/machine v0.0.0-20200807140942-881bba45a0a3 h1:U9/XZbBTs7kr2S4ZMvh1HXdSY5ClGXf3ZqzEvFkhH5Y=
+github.com/code-ready/machine v0.0.0-20200807140942-881bba45a0a3/go.mod h1:g30jKsf0FV9yJjsqZFAuFzVxwJE2h5cqDXSuMUV1G/U=
+github.com/code-ready/machine v0.0.0-20200810103403-d2277fb226c4 h1:7rvtC0pR4q6UXWpywkvpYhHpIk5b5g27al2wLynx7sI=
+github.com/code-ready/machine v0.0.0-20200810103403-d2277fb226c4/go.mod h1:g30jKsf0FV9yJjsqZFAuFzVxwJE2h5cqDXSuMUV1G/U=
 github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/gofrs/uuid v3.2.0+incompatible/go.mod h1:b2aQJv3Z4Fp6yNu3cdSllBxTCLRxnplIgP/c0N/04lM=

--- a/libvirt.go
+++ b/libvirt.go
@@ -16,6 +16,7 @@ import (
 	"github.com/libvirt/libvirt-go"
 
 	// Machine-drivers
+	libvirtdriver "github.com/code-ready/machine/drivers/libvirt"
 	"github.com/code-ready/machine/libmachine/drivers"
 	"github.com/code-ready/machine/libmachine/log"
 	"github.com/code-ready/machine/libmachine/mcnflag"
@@ -24,19 +25,7 @@ import (
 )
 
 type Driver struct {
-	*drivers.BaseDriver
-
-	// SSH key Path
-	SSHKeyPath string
-
-	// Driver specific configuration
-	Memory      int
-	CPU         int
-	Network     string
-	DiskPath    string
-	DiskPathURL string
-	CacheMode   string
-	IOMode      string
+	*libvirtdriver.Driver
 
 	// Libvirt connection and state
 	connectionString string
@@ -562,11 +551,15 @@ func (d *Driver) GetIP() (string, error) {
 
 func NewDriver(hostName, storePath string) drivers.Driver {
 	return &Driver{
-		Network: DefaultNetwork,
-		BaseDriver: &drivers.BaseDriver{
-			MachineName: hostName,
-			StorePath:   storePath,
-			SSHUser:     DefaultSSHUser,
+		Driver: &libvirtdriver.Driver{
+			VMDriver: &drivers.VMDriver{
+				BaseDriver: &drivers.BaseDriver{
+					MachineName: hostName,
+					StorePath:   storePath,
+					SSHUser:     DefaultSSHUser,
+				},
+			},
+			Network: DefaultNetwork,
 		},
 	}
 }


### PR DESCRIPTION
This will ensure both users (crc and machine-driver-libvirt) are kept in sync.