### PR TITLE
Use machine name as disk name

### DIFF
--- a/libvirt.go
+++ b/libvirt.go
@@ -235,7 +235,7 @@ func (d *Driver) PreCreateCheck() error {
 }
 
 func (d *Driver) Create() error {
-	b2dutils := mcnutils.NewB2dUtils(d.StorePath, "crc")
+	b2dutils := mcnutils.NewB2dUtils(d.StorePath, d.MachineName)
 	if err := b2dutils.CopyDiskToMachineDir(d.DiskPathURL, d.MachineName); err != nil {
 		return err
 	}


### PR DESCRIPTION
When compiling crc with a name different than crc, the machine won't start because the disk image name is not the right one. See https://github.com/code-ready/crc/blob/d2b83d6a75b9522fba12b1eaf28f38dc799535f7/pkg/crc/machine/libvirt/driver_linux.go#L39