### PR TITLE
Add support for changing memory allocated to an already existing VM

### DIFF
--- a/constants.go
+++ b/constants.go
@@ -4,7 +4,7 @@ import "fmt"
 
 const (
 	DriverName    = "libvirt"
-	DriverVersion = "0.12.9"
+	DriverVersion = "0.12.10"
 
 	connectionString = "qemu:///system"
 	dnsmasqStatus    = "/var/lib/libvirt/dnsmasq/%s.status"

--- a/go.mod
+++ b/go.mod
@@ -1,7 +1,7 @@
 module github.com/code-ready/machine-driver-libvirt
 
 require (
-	github.com/code-ready/machine v0.0.0-20200914130222-4c6e6576e87a
+	github.com/code-ready/machine v0.0.0-20200917080012-b562dd1312da
 	github.com/libvirt/libvirt-go v3.4.0+incompatible
 	github.com/stretchr/objx v0.3.0 // indirect
 	github.com/stretchr/testify v1.6.1

--- a/go.mod
+++ b/go.mod
@@ -1,7 +1,7 @@
 module github.com/code-ready/machine-driver-libvirt
 
 require (
-	github.com/code-ready/machine v0.0.0-20200903081832-ffa0b31fbdb3
+	github.com/code-ready/machine v0.0.0-20200914130222-4c6e6576e87a
 	github.com/libvirt/libvirt-go v3.4.0+incompatible
 	github.com/stretchr/objx v0.3.0 // indirect
 	github.com/stretchr/testify v1.6.1

--- a/go.sum
+++ b/go.sum
@@ -12,6 +12,8 @@ github.com/code-ready/machine v0.0.0-20200914130222-4c6e6576e87a h1:SI+ojl7up54z
 github.com/code-ready/machine v0.0.0-20200914130222-4c6e6576e87a/go.mod h1:g30jKsf0FV9yJjsqZFAuFzVxwJE2h5cqDXSuMUV1G/U=
 github.com/code-ready/machine v0.0.0-20200914130222-8fb9497666ab h1:56RlouIod7gpu4OayF0/qkGUdes7mH7DIshHnchA7Ds=
 github.com/code-ready/machine v0.0.0-20200914130222-8fb9497666ab/go.mod h1:g30jKsf0FV9yJjsqZFAuFzVxwJE2h5cqDXSuMUV1G/U=
+github.com/code-ready/machine v0.0.0-20200917080012-b562dd1312da h1:sWsWZUiTP45ukBcukit91Tda58iRiRYTXHjqnKzsAB4=
+github.com/code-ready/machine v0.0.0-20200917080012-b562dd1312da/go.mod h1:g30jKsf0FV9yJjsqZFAuFzVxwJE2h5cqDXSuMUV1G/U=
 github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=

--- a/go.sum
+++ b/go.sum
@@ -8,6 +8,10 @@ github.com/code-ready/machine v0.0.0-20200810103403-d2277fb226c4 h1:7rvtC0pR4q6U
 github.com/code-ready/machine v0.0.0-20200810103403-d2277fb226c4/go.mod h1:g30jKsf0FV9yJjsqZFAuFzVxwJE2h5cqDXSuMUV1G/U=
 github.com/code-ready/machine v0.0.0-20200903081832-ffa0b31fbdb3 h1:p6QhNf5a/ThRdPydIXyBmwVutNyRxY3yQgXvjeGf8nM=
 github.com/code-ready/machine v0.0.0-20200903081832-ffa0b31fbdb3/go.mod h1:g30jKsf0FV9yJjsqZFAuFzVxwJE2h5cqDXSuMUV1G/U=
+github.com/code-ready/machine v0.0.0-20200914130222-4c6e6576e87a h1:SI+ojl7up54ziVmsRvT+48JbM9BuxFOz+Eq6ln1Kfcs=
+github.com/code-ready/machine v0.0.0-20200914130222-4c6e6576e87a/go.mod h1:g30jKsf0FV9yJjsqZFAuFzVxwJE2h5cqDXSuMUV1G/U=
+github.com/code-ready/machine v0.0.0-20200914130222-8fb9497666ab h1:56RlouIod7gpu4OayF0/qkGUdes7mH7DIshHnchA7Ds=
+github.com/code-ready/machine v0.0.0-20200914130222-8fb9497666ab/go.mod h1:g30jKsf0FV9yJjsqZFAuFzVxwJE2h5cqDXSuMUV1G/U=
 github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=

--- a/libvirt.go
+++ b/libvirt.go
@@ -161,7 +161,7 @@ func (d *Driver) validateNetwork() error {
 	}
 	network, err := conn.LookupNetworkByName(d.Network)
 	if err != nil {
-		return fmt.Errorf("Use 'crc setup' for define the network, %+v", err)
+		return fmt.Errorf("Use 'crc setup' to define the network, %+v", err)
 	}
 	xmldoc, err := network.GetXMLDesc(0)
 	if err != nil {

--- a/libvirt.go
+++ b/libvirt.go
@@ -32,7 +32,7 @@ type Driver struct {
 
 	// Libvirt connection and state
 	conn     *libvirt.Connect
-	VM       *libvirt.Domain
+	vm       *libvirt.Domain
 	vmLoaded bool
 }
 
@@ -277,7 +277,7 @@ func (d *Driver) Create() error {
 		log.Warnf("Failed to create the VM: %s", err)
 		return err
 	}
-	d.VM = vm
+	d.vm = vm
 	d.vmLoaded = true
 	log.Debugf("Adding the file: %s", filepath.Join(d.ResolveStorePath("."), fmt.Sprintf(".%s-exist", d.MachineName)))
 	_, _ = os.OpenFile(filepath.Join(d.ResolveStorePath("."), fmt.Sprintf(".%s-exist", d.MachineName)), os.O_RDONLY|os.O_CREATE, 0666)
@@ -337,7 +337,7 @@ func (d *Driver) Start() error {
 	if err := d.validateVMRef(); err != nil {
 		return err
 	}
-	if err := d.VM.Create(); err != nil {
+	if err := d.vm.Create(); err != nil {
 		log.Warnf("Failed to start: %s", err)
 		return err
 	}
@@ -386,7 +386,7 @@ func (d *Driver) Stop() error {
 	}
 
 	if s != state.Stopped {
-		err := d.VM.Shutdown()
+		err := d.vm.Shutdown()
 		if err != nil {
 			log.Warnf("Failed to gracefully shutdown VM")
 			return err
@@ -412,8 +412,8 @@ func (d *Driver) Remove() error {
 	// Note: If we switch to qcow disks instead of raw the user
 	//       could take a snapshot.  If you do, then Undefine
 	//       will fail unless we nuke the snapshots first
-	_ = d.VM.Destroy() // Ignore errors
-	return d.VM.Undefine()
+	_ = d.vm.Destroy() // Ignore errors
+	return d.vm.Undefine()
 }
 
 func (d *Driver) Restart() error {
@@ -429,7 +429,7 @@ func (d *Driver) Kill() error {
 	if err := d.validateVMRef(); err != nil {
 		return err
 	}
-	return d.VM.Destroy()
+	return d.vm.Destroy()
 }
 
 func (d *Driver) GetState() (state.State, error) {
@@ -437,7 +437,7 @@ func (d *Driver) GetState() (state.State, error) {
 	if err := d.validateVMRef(); err != nil {
 		return state.None, err
 	}
-	virState, _, err := d.VM.GetState()
+	virState, _, err := d.vm.GetState()
 	if err != nil {
 		return state.None, err
 	}
@@ -475,7 +475,7 @@ func (d *Driver) validateVMRef() error {
 			log.Warnf("Failed to fetch machine")
 			return fmt.Errorf("Failed to fetch machine '%s'", d.MachineName)
 		}
-		d.VM = vm
+		d.vm = vm
 		d.vmLoaded = true
 	}
 	return nil
@@ -487,7 +487,7 @@ func (d *Driver) getMAC() (string, error) {
 	if err := d.validateVMRef(); err != nil {
 		return "", err
 	}
-	xmldoc, err := d.VM.GetXMLDesc(0)
+	xmldoc, err := d.vm.GetXMLDesc(0)
 	if err != nil {
 		return "", err
 	}

--- a/libvirt.go
+++ b/libvirt.go
@@ -163,6 +163,8 @@ func (d *Driver) validateNetwork() error {
 	if err != nil {
 		return fmt.Errorf("Use 'crc setup' to define the network, %+v", err)
 	}
+	defer network.Free() // nolint:errcheck
+
 	xmldoc, err := network.GetXMLDesc(0)
 	if err != nil {
 		return err
@@ -538,6 +540,7 @@ func (d *Driver) getIPByMacFromSettings(mac string) (string, error) {
 		log.Warnf("Failed to find network: %s", err)
 		return "", err
 	}
+	defer network.Free() // nolint:errcheck
 	bridgeName, err := network.GetBridgeName()
 	if err != nil {
 		log.Warnf("Failed to get network bridge: %s", err)

--- a/libvirt_test.go
+++ b/libvirt_test.go
@@ -15,14 +15,14 @@ func TestTemplating(t *testing.T) {
 				BaseDriver: &drivers.BaseDriver{
 					MachineName: "domain",
 				},
-				DiskPathURL: "disk_path",
-				Memory:      4096,
-				CPU:         4,
+				ImageSourcePath: "disk_path",
+				ImageFormat:     "test",
+				Memory:          4096,
+				CPU:             4,
 			},
 			Network:   "network",
 			CacheMode: "default",
 			IOMode:    "threads",
-			DiskPath:  "disk_path",
 			VSock:     false,
 		},
 	})
@@ -53,7 +53,7 @@ func TestTemplating(t *testing.T) {
   <devices>
     <disk type='file' device='disk'>
       <driver name='qemu' type='qcow2' cache='default' io='threads' />
-      <source file='disk_path'/>
+      <source file='machines/domain/domain.test'/>
       <target dev='vda' bus='virtio'/>
     </disk>
     <graphics type='vnc' autoport='yes' listen='127.0.0.1'>
@@ -82,14 +82,14 @@ func TestVSockTemplating(t *testing.T) {
 				BaseDriver: &drivers.BaseDriver{
 					MachineName: "domain",
 				},
-				DiskPathURL: "disk_path",
-				Memory:      4096,
-				CPU:         4,
+				ImageSourcePath: "disk_path",
+				ImageFormat:     "test",
+				Memory:          4096,
+				CPU:             4,
 			},
 			Network:   "crc",
 			CacheMode: "default",
 			IOMode:    "threads",
-			DiskPath:  "disk_path",
 			VSock:     true,
 		},
 	})
@@ -104,14 +104,14 @@ func TestNetworkTemplating(t *testing.T) {
 				BaseDriver: &drivers.BaseDriver{
 					MachineName: "domain",
 				},
-				DiskPathURL: "disk_path",
-				Memory:      4096,
-				CPU:         4,
+				ImageSourcePath: "disk_path",
+				ImageFormat:     "test",
+				Memory:          4096,
+				CPU:             4,
 			},
 			Network:   "crc",
 			CacheMode: "default",
 			IOMode:    "threads",
-			DiskPath:  "disk_path",
 			VSock:     true,
 		},
 	})


### PR DESCRIPTION
This is the machine-driver-libvirt implementation for the changes done in https://github.com/code-ready/machine/pull/39
It's missing the needed go.mod/go.sum updates, this PR will be updated after the machine PR is finalized.