### PR TITLE
Redirect console to a log file

### DIFF
--- a/constants.go
+++ b/constants.go
@@ -46,7 +46,9 @@ const (
     <graphics type='vnc' autoport='yes' listen='127.0.0.1'>
       <listen type='address' address='127.0.0.1'/>
     </graphics>
-    <console type='pty'></console>
+    <console type='pty'>
+      <log file="{{ .SerialPath }}" append="on"/>
+    </console>
     <channel type='pty'>
       <target type='virtio' name='org.qemu.guest_agent.0'/>
     </channel>

--- a/libvirt.go
+++ b/libvirt.go
@@ -77,6 +77,7 @@ type DomainConfig struct {
 	CacheMode    string
 	IOMode       string
 	DiskPath     string
+	SerialPath   string
 	ExtraDevices []string
 }
 
@@ -373,6 +374,7 @@ func domainXML(d *Driver) (string, error) {
 		CacheMode:  d.CacheMode,
 		IOMode:     d.IOMode,
 		DiskPath:   d.getDiskPath(),
+		SerialPath: fmt.Sprintf("/var/log/libvirt/qemu/%s-serial.log", d.MachineName),
 	}
 	if d.Network != "" {
 		config.ExtraDevices = append(config.ExtraDevices, NetworkDevice(d.Network))

--- a/libvirt_test.go
+++ b/libvirt_test.go
@@ -59,7 +59,9 @@ func TestTemplating(t *testing.T) {
     <graphics type='vnc' autoport='yes' listen='127.0.0.1'>
       <listen type='address' address='127.0.0.1'/>
     </graphics>
-    <console type='pty'></console>
+    <console type='pty'>
+      <log file="/var/log/libvirt/qemu/domain-serial.log" append="on"/>
+    </console>
     <channel type='pty'>
       <target type='virtio' name='org.qemu.guest_agent.0'/>
     </channel>


### PR DESCRIPTION
This is something we should ask users to provide when they open a ticket.

This idea was triggered by this ticket where we are completely blind: https://github.com/code-ready/crc/issues/1555
The log filepath could probably be better but the permission are root:root and I can't put it in the machine directory.