### PR TITLE
Add missing backing file format

### DIFF
--- a/libvirt.go
+++ b/libvirt.go
@@ -398,6 +398,7 @@ func createImage(src, dst string) error {
 	cmd := exec.Command("qemu-img",
 		"create",
 		"-f", "qcow2",
+		"-F", "qcow2",
 		"-o", fmt.Sprintf("backing_file=%s", src),
 		dst)
 	if err := cmd.Run(); err != nil {


### PR DESCRIPTION
This prevents "format of backing image
'../.crc/cache/crc_libvirt_4.5.14/crc.qcow2' of image
'/.../.crc/machines/crc/crc.qcow2' was not specified in the image
metadata" failure to happen. This flag was not necessary for people
running Fedora 32 but is mandatory for Ubuntu 20.04.

Related to https://github.com/code-ready/crc/issues/1596