### PR TITLE
Use dhcp leases contained in net-dumpxml to get VM IP

### DIFF
--- a/pkg/libvirt/constants.go
+++ b/pkg/libvirt/constants.go
@@ -5,7 +5,6 @@ const (
 	DriverVersion = "0.12.11"
 
 	connectionString = "qemu:///system"
-	dnsmasqStatus    = "/var/lib/libvirt/dnsmasq/%s.status"
 	DefaultMemory    = 8096
 	DefaultCPUs      = 4
 	DefaultNetwork   = "crc"


### PR DESCRIPTION
Move away from reading the IP from the dnsmasq file, and instead use
the equivalent of virsh net-dumpxml command.
The driver doesnt assume anything about the filesystem and only uses the
libvirt API.