### PR TITLE
Misc improvements to the libvirt domain XML

### DIFF
--- a/pkg/libvirt/domain.go
+++ b/pkg/libvirt/domain.go
@@ -24,6 +24,7 @@ func domainXML(d *Driver) (string, error) {
 		},
 		CPU: &libvirtxml.DomainCPU{
 			Mode: "host-passthrough",
+			// https://bugzilla.redhat.com/show_bug.cgi?id=1806532
 			Features: []libvirtxml.DomainCPUFeature{
 				{
 					Policy: "disable",

--- a/pkg/libvirt/domain.go
+++ b/pkg/libvirt/domain.go
@@ -98,6 +98,9 @@ func domainXML(d *Driver) (string, error) {
 					},
 				},
 			},
+			MemBalloon: &libvirtxml.DomainMemBalloon{
+				Model: "none",
+			},
 		},
 	}
 	if d.Network != "" {

--- a/pkg/libvirt/domain.go
+++ b/pkg/libvirt/domain.go
@@ -4,6 +4,8 @@ import (
 	libvirtxml "github.com/libvirt/libvirt-go-xml"
 )
 
+const macAddress = "52:fd:fc:07:21:82"
+
 func domainXML(d *Driver) (string, error) {
 	domain := libvirtxml.Domain{
 		Type: "kvm",
@@ -102,7 +104,7 @@ func domainXML(d *Driver) (string, error) {
 		domain.Devices.Interfaces = []libvirtxml.DomainInterface{
 			{
 				MAC: &libvirtxml.DomainInterfaceMAC{
-					Address: "52:fd:fc:07:21:82",
+					Address: macAddress,
 				},
 				Source: &libvirtxml.DomainInterfaceSource{
 					Network: &libvirtxml.DomainInterfaceSourceNetwork{

--- a/pkg/libvirt/domain.go
+++ b/pkg/libvirt/domain.go
@@ -34,7 +34,8 @@ func domainXML(d *Driver) (string, error) {
 		},
 		OS: &libvirtxml.DomainOS{
 			Type: &libvirtxml.DomainOSType{
-				Type: "hvm",
+				Machine: "q35",
+				Type:    "hvm",
 			},
 			BootDevices: []libvirtxml.DomainBootDevice{
 				{

--- a/pkg/libvirt/domain.go
+++ b/pkg/libvirt/domain.go
@@ -15,8 +15,7 @@ func domainXML(d *Driver) (string, error) {
 			Unit:  "MB",
 		},
 		VCPU: &libvirtxml.DomainVCPU{
-			Placement: "static",
-			Value:     uint(d.CPU),
+			Value: uint(d.CPU),
 		},
 		Features: &libvirtxml.DomainFeatureList{
 			ACPI: &libvirtxml.DomainFeature{},
@@ -34,7 +33,6 @@ func domainXML(d *Driver) (string, error) {
 		},
 		OS: &libvirtxml.DomainOS{
 			Type: &libvirtxml.DomainOSType{
-				Arch: "x86_64",
 				Type: "hvm",
 			},
 			BootDevices: []libvirtxml.DomainBootDevice{
@@ -72,17 +70,7 @@ func domainXML(d *Driver) (string, error) {
 			},
 			Graphics: []libvirtxml.DomainGraphic{
 				{
-					VNC: &libvirtxml.DomainGraphicVNC{
-						AutoPort: "yes",
-						Listen:   "127.0.0.1",
-						Listeners: []libvirtxml.DomainGraphicListener{
-							{
-								Address: &libvirtxml.DomainGraphicListenerAddress{
-									Address: "127.0.0.1",
-								},
-							},
-						},
-					},
+					VNC: &libvirtxml.DomainGraphicVNC{},
 				},
 			},
 			Consoles: []libvirtxml.DomainConsole{

--- a/pkg/libvirt/domain_test.go
+++ b/pkg/libvirt/domain_test.go
@@ -33,7 +33,7 @@ func TestTemplating(t *testing.T) {
   <memory unit="MB">4096</memory>
   <vcpu>4</vcpu>
   <os>
-    <type>hvm</type>
+    <type machine="q35">hvm</type>
     <boot dev="hd"></boot>
     <bootmenu enable="no"></bootmenu>
   </os>

--- a/pkg/libvirt/domain_test.go
+++ b/pkg/libvirt/domain_test.go
@@ -31,9 +31,9 @@ func TestTemplating(t *testing.T) {
 	assert.Equal(t, `<domain type="kvm">
   <name>domain</name>
   <memory unit="MB">4096</memory>
-  <vcpu placement="static">4</vcpu>
+  <vcpu>4</vcpu>
   <os>
-    <type arch="x86_64">hvm</type>
+    <type>hvm</type>
     <boot dev="hd"></boot>
     <bootmenu enable="no"></bootmenu>
   </os>
@@ -58,9 +58,7 @@ func TestTemplating(t *testing.T) {
       <model type="virtio"></model>
     </interface>
     <console></console>
-    <graphics type="vnc" autoport="yes" listen="127.0.0.1">
-      <listen type="address" address="127.0.0.1"></listen>
-    </graphics>
+    <graphics type="vnc"></graphics>
     <memballoon model="none"></memballoon>
     <rng model="virtio">
       <backend model="random">/dev/urandom</backend>

--- a/pkg/libvirt/domain_test.go
+++ b/pkg/libvirt/domain_test.go
@@ -61,6 +61,7 @@ func TestTemplating(t *testing.T) {
     <graphics type="vnc" autoport="yes" listen="127.0.0.1">
       <listen type="address" address="127.0.0.1"></listen>
     </graphics>
+    <memballoon model="none"></memballoon>
     <rng model="virtio">
       <backend model="random">/dev/urandom</backend>
     </rng>

--- a/pkg/libvirt/libvirt.go
+++ b/pkg/libvirt/libvirt.go
@@ -68,16 +68,6 @@ func (d *Driver) GetCreateFlags() []mcnflag.Flag {
 	}
 }
 
-type DomainConfig struct {
-	DomainName   string
-	Memory       int
-	CPU          int
-	CacheMode    string
-	IOMode       string
-	DiskPath     string
-	ExtraDevices []string
-}
-
 func (d *Driver) GetMachineName() string {
 	return d.MachineName
 }


### PR DESCRIPTION
Most important change is the switch from i440fx to q35 chipset.
This also removes some attributes/elements which are set at their default
values, and does a few more small cleanups.