### PR TITLE
Fixes for disk resize

### DIFF
--- a/pkg/libvirt/storage.go
+++ b/pkg/libvirt/storage.go
@@ -156,6 +156,9 @@ func (d *Driver) resizeDiskImage(newCapacity uint64) error {
 		log.Debugf("disk image capacity is already %d bytes", capacity)
 		return nil
 	}
+	if capacity > newCapacity {
+		return fmt.Errorf("current disk image capacity is bigger than the requested size (%d > %d)", capacity, newCapacity)
+	}
 
 	vol, err := d.getVolume()
 	if err != nil {

--- a/pkg/libvirt/storage.go
+++ b/pkg/libvirt/storage.go
@@ -146,10 +146,10 @@ func (d *Driver) checkIfResizeNeeded(newCapacity uint64) (bool, error) {
 	}
 	capacity, err := d.getVolCapacity()
 	if err != nil {
-		log.Infof("could not get volume capacity: %v", err)
+		log.Debugf("failed to get volume capacity")
 		return false, err
 	}
-	log.Infof("volume capacity is %d", capacity)
+
 	if capacity == newCapacity {
 		log.Debugf("disk image capacity is already %d bytes", capacity)
 		return false, nil
@@ -182,12 +182,11 @@ func (d *Driver) resizeDiskImage(newCapacity uint64) error {
 	}
 	defer vol.Free() // nolint:errcheck
 
-	log.Infof("resizing volume to %d", newCapacity)
+	log.Debugf("resizing volume to %d", newCapacity)
 	err = vol.Resize(newCapacity, 0)
 	if err == nil {
 		d.DiskCapacity = newCapacity
 	}
-	log.Infof("vol.Resize result: %v", err)
 
 	return err
 }


### PR DESCRIPTION
Most important one is `Resize disk images at creation time as well` which is required for
`crc delete && crc start --disk-size xxx` to work.