### PR TITLE
Only use q35 machine type if supported

### DIFF
--- a/pkg/libvirt/domain.go
+++ b/pkg/libvirt/domain.go
@@ -6,7 +6,7 @@ import (
 
 const macAddress = "52:fd:fc:07:21:82"
 
-func domainXML(d *Driver) (string, error) {
+func domainXML(d *Driver, machineType string) (string, error) {
 	domain := libvirtxml.Domain{
 		Type: "kvm",
 		Name: d.MachineName,
@@ -34,8 +34,7 @@ func domainXML(d *Driver) (string, error) {
 		},
 		OS: &libvirtxml.DomainOS{
 			Type: &libvirtxml.DomainOSType{
-				Machine: "q35",
-				Type:    "hvm",
+				Type: "hvm",
 			},
 			BootDevices: []libvirtxml.DomainBootDevice{
 				{
@@ -92,6 +91,9 @@ func domainXML(d *Driver) (string, error) {
 				Model: "none",
 			},
 		},
+	}
+	if machineType != "" {
+		domain.OS.Type.Machine = machineType
 	}
 	if d.Network != "" {
 		domain.Devices.Interfaces = []libvirtxml.DomainInterface{

--- a/pkg/libvirt/domain_test.go
+++ b/pkg/libvirt/domain_test.go
@@ -25,7 +25,7 @@ func TestTemplating(t *testing.T) {
 			IOMode:    "threads",
 			VSock:     false,
 		},
-	})
+	}, "q35")
 
 	assert.NoError(t, err)
 	assert.Equal(t, `<domain type="kvm">
@@ -84,9 +84,10 @@ func TestVSockTemplating(t *testing.T) {
 			IOMode:    "threads",
 			VSock:     true,
 		},
-	})
+	}, "")
 	assert.NoError(t, err)
 	assert.Regexp(t, `(?s)<devices>(.*?)<vsock model="virtio">\s*<cid auto="yes">\s*</cid>\s*</vsock>(.*?)</devices>`, xml)
+	assert.Regexp(t, `(?s)<os>(.*?)<type>hvm</type>(.*?)</os>`, xml)
 }
 
 func TestNetworkTemplating(t *testing.T) {
@@ -106,7 +107,7 @@ func TestNetworkTemplating(t *testing.T) {
 			IOMode:    "threads",
 			VSock:     true,
 		},
-	})
+	}, "q35")
 	assert.NoError(t, err)
 	assert.Contains(t, xml, `<interface type="network">
       <mac address="52:fd:fc:07:21:82"></mac>


### PR DESCRIPTION
Default EL7 qemu version does not support the q35 machine type.
Trying to create a VM which uses it will fail, and thus unconditionally
using q35 means crc no longer works on EL7.
This can be worked around by using the qemu-ev package, which needs
additional subscription, or by upgrading to EL8.

This commit will only try to use q35 if it's available.

This fixes https://github.com/code-ready/crc/issues/1708