### PR TITLE
Move copy code where it is used

### DIFF
--- a/pkg/libvirt/copy.go
+++ b/pkg/libvirt/copy.go
@@ -1,0 +1,33 @@
+package libvirt
+
+import (
+	"io"
+	"os"
+)
+
+func copyFile(src, dst string) error {
+	in, err := os.Open(src)
+	if err != nil {
+		return err
+	}
+
+	defer in.Close()
+
+	out, err := os.Create(dst)
+	if err != nil {
+		return err
+	}
+
+	defer out.Close()
+
+	if _, err = io.Copy(out, in); err != nil {
+		return err
+	}
+
+	fi, err := os.Stat(src)
+	if err != nil {
+		return err
+	}
+
+	return os.Chmod(dst, fi.Mode())
+}

--- a/pkg/libvirt/copy_test.go
+++ b/pkg/libvirt/copy_test.go
@@ -1,0 +1,53 @@
+package libvirt
+
+import (
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestCopyFile(t *testing.T) {
+	testStr := "test-machine"
+
+	srcFile, err := ioutil.TempFile("", "machine-test-")
+	if err != nil {
+		t.Fatal(err)
+	}
+	srcFi, err := srcFile.Stat()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	_, _ = srcFile.Write([]byte(testStr))
+	srcFile.Close()
+
+	srcFilePath := filepath.Join(os.TempDir(), srcFi.Name())
+
+	destFile, err := ioutil.TempFile("", "machine-copy-test-")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	destFi, err := destFile.Stat()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	destFile.Close()
+
+	destFilePath := filepath.Join(os.TempDir(), destFi.Name())
+
+	if err := copyFile(srcFilePath, destFilePath); err != nil {
+		t.Fatal(err)
+	}
+
+	data, err := ioutil.ReadFile(destFilePath)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if string(data) != testStr {
+		t.Fatalf("expected data \"%s\"; received \"%s\"", testStr, string(data))
+	}
+}

--- a/pkg/libvirt/libvirt.go
+++ b/pkg/libvirt/libvirt.go
@@ -16,7 +16,6 @@ import (
 	libvirtdriver "github.com/code-ready/machine/drivers/libvirt"
 	"github.com/code-ready/machine/libmachine/drivers"
 	"github.com/code-ready/machine/libmachine/log"
-	"github.com/code-ready/machine/libmachine/mcnutils"
 	"github.com/code-ready/machine/libmachine/state"
 )
 
@@ -344,7 +343,7 @@ func createImage(src, dst string) error {
 		dst)
 	if err := cmd.Run(); err != nil {
 		log.Debugf("qemu-img create failed, falling back to copy: %v", err)
-		return mcnutils.CopyFile(src, dst)
+		return copyFile(src, dst)
 	}
 	return nil
 }


### PR DESCRIPTION
There is no need to share this kind of code in a global library.
It's better to have duplication than depending too much on machine code.