### PR TITLE
Add spec file to machine-driver-libvirt

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,7 +5,7 @@ version: 2
 jobs:
   build:
     machine:
-       image: circleci/classic:201808-01
+       image: ubuntu-2004:202101-01
 
 ## Build crc-libvirt-driver
     working_directory: ~/work

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -14,6 +14,9 @@ jobs:
     - run:
        name: Build driver binary
        command: make CONTAINER_RUNTIME="docker"
+    - run:
+        name: Test RPM build
+        command: make CONTAINER_RUNTIME="docker" test-rpmbuild
     - store_artifacts:
        path: ~/work/crc-driver-libvirt-centos8
        destination: crc-driver-libvirt

--- a/Containerfile.rpmbuild
+++ b/Containerfile.rpmbuild
@@ -1,0 +1,10 @@
+FROM registry.centos.org/centos
+WORKDIR $APP_ROOT/src
+RUN yum -y install git-core rpm-build dnf-plugins-core 'dnf-command(builddep)'
+COPY . .
+RUN mkdir -p ~/rpmbuild/SOURCES/ && \
+    export VERSION=$(rpmspec  -q --qf %{Version} --srpm crc-driver-libvirt.spec) && \
+    git archive --format=tar --prefix=machine-driver-libvirt-${VERSION}/ HEAD | gzip >~/rpmbuild/SOURCES/machine-driver-libvirt-${VERSION}.tar.gz
+RUN yum config-manager --set-enabled powertools && \
+    yum -y builddep crc-driver-libvirt.spec && \
+    rpmbuild -bb -v crc-driver-libvirt.spec

--- a/Makefile
+++ b/Makefile
@@ -61,8 +61,11 @@ vendor:
 	go mod tidy
 	go mod vendor
 
-.PHONY: spec
+.PHONY: spec test-rpmbuild
 spec: crc-driver-libvirt.spec
+
+test-rpmbuild: spec
+	${CONTAINER_RUNTIME} build -f Containerfile.rpmbuild .
 
 $(gopath)/bin/gomod2rpmdeps:
 	(cd /tmp && GO111MODULE=on go get github.com/cfergeau/gomod2rpmdeps/cmd/gomod2rpmdeps)

--- a/crc-driver-libvirt.spec.in
+++ b/crc-driver-libvirt.spec.in
@@ -1,0 +1,71 @@
+# https://github.com/code-ready/machine-driver-libvirt
+%global goipath         github.com/code-ready/machine-driver-libvirt
+Version:                0.12.14
+
+%gometa
+
+%global gobuilddir %{_builddir}/%{archivename}/_build
+
+# debuginfo is not supported with Go
+%global debug_package %{nil}
+%global _enable_debug_package 0
+
+%global common_description %{expand:
+CodeReady Container's libvirt machine driver}
+
+
+%global golicenses    LICENSE
+%global godocs        *.md
+
+Name:           %{goname}
+Release:        2%{?dist}
+Summary:        CodeReady Container's libvirt machine driver
+License:        ASL 2.0
+URL:            %{gourl}
+Source0:        %{gosource}
+
+BuildRequires: pkgconfig(libvirt)
+BuildRequires: go-srpm-macros
+BuildRequires: git-core
+
+__BUNDLED_REQUIRES__
+
+%description
+%{common_description}
+
+%gopkg
+
+
+%prep
+# with fedora macros: goprep -k
+%autosetup -S git -n %{archivename}
+install -m 0755 -vd "$(dirname %{gobuilddir}/src/%{goipath})"
+ln -fs "$(pwd)" "%{gobuilddir}/src/%{goipath}"
+
+
+%build
+export GO111MODULE=off
+export GOPATH=$(pwd)/_build:$(pwd)
+%gobuild -o %{gobuilddir}/bin/crc-driver-libvirt %{goipath}/cmd/machine-driver-libvirt
+
+
+%install
+# with fedora macros: gopkginstall
+install -m 0755 -vd                     %{buildroot}%{_bindir}
+install -m 0755 -vp %{gobuilddir}/bin/* %{buildroot}%{_bindir}/
+
+
+%check
+# with fedora macros: gocheck
+# This requires golangci-lint, so disabled for now
+#go test ./...
+
+
+%files
+%license %{golicenses}
+%doc
+%{_bindir}/*
+
+%changelog
+* Wed Feb 03 2021 Christophe Fergeau <cfergeau@redhat.com> - 0.12.14-1
+- Initial import in Fedora


### PR DESCRIPTION
This adds a `make spec` target which generates a spec file for use on Red Hat infrastructure.
I did not test this .spec file against fedora, but hopefully it works there as well.
This introduces a gomod2rpmreqs helper to convert the list of go module used by
machine-driver-libvirt to virtual rpm Requires, for better tracking of what
code machine-driver-libvirt is vendoring.