### PR TITLE
start: Return error when failing to get IP

### DIFF
--- a/pkg/libvirt/libvirt.go
+++ b/pkg/libvirt/libvirt.go
@@ -400,6 +400,7 @@ func (d *Driver) Start() error {
 
 	if d.IPAddress == "" {
 		log.Warnf("Unable to determine VM's IP address, did it fail to boot?")
+		return fmt.Errorf("Unable to determine VM's IP address, did it fail to boot?")
 	}
 	return nil
 }


### PR DESCRIPTION
At the moment, nil is returned when Start() fails to gets the VM IP
crc's code assumes that when Start() returns, the VM has an IP.
This should help catch this situation.

This is related to https://github.com/code-ready/crc/issues/2214