### PR TITLE
Reduce the number of states

### DIFF
--- a/pkg/libvirt/libvirt.go
+++ b/pkg/libvirt/libvirt.go
@@ -474,12 +474,8 @@ func (d *Driver) GetState() (state.State, error) {
 	switch virState {
 	case libvirt.DOMAIN_RUNNING:
 		return state.Running, nil
-	case libvirt.DOMAIN_PAUSED:
-		return state.Paused, nil
 	case libvirt.DOMAIN_SHUTDOWN:
 		return state.Stopped, nil
-	case libvirt.DOMAIN_PMSUSPENDED:
-		return state.Saved, nil
 	case libvirt.DOMAIN_SHUTOFF:
 		return state.Stopped, nil
 	}

--- a/pkg/libvirt/libvirt.go
+++ b/pkg/libvirt/libvirt.go
@@ -467,7 +467,7 @@ func (d *Driver) GetState() (state.State, error) {
 	if err := d.validateVMRef(); err != nil {
 		return state.Error, err
 	}
-	virState, _, err := d.vm.GetState()
+	virState, reason, err := d.vm.GetState()
 	if err != nil {
 		return state.Error, err
 	}
@@ -478,6 +478,10 @@ func (d *Driver) GetState() (state.State, error) {
 		return state.Stopped, nil
 	case libvirt.DOMAIN_SHUTOFF:
 		return state.Stopped, nil
+	case libvirt.DOMAIN_PAUSED:
+		if libvirt.DomainPausedReason(reason) == libvirt.DOMAIN_PAUSED_STARTING_UP {
+			return state.Running, nil
+		}
 	}
 	return state.Error, fmt.Errorf("unexpected libvirt status %d", virState)
 }

--- a/pkg/libvirt/libvirt.go
+++ b/pkg/libvirt/libvirt.go
@@ -475,7 +475,7 @@ func (d *Driver) GetState() (state.State, error) {
 	case libvirt.DOMAIN_RUNNING:
 		return state.Running, nil
 	case libvirt.DOMAIN_SHUTDOWN:
-		return state.Stopped, nil
+		return state.Running, nil
 	case libvirt.DOMAIN_SHUTOFF:
 		return state.Stopped, nil
 	case libvirt.DOMAIN_PAUSED:

--- a/pkg/libvirt/libvirt.go
+++ b/pkg/libvirt/libvirt.go
@@ -465,32 +465,25 @@ func (d *Driver) Kill() error {
 func (d *Driver) GetState() (state.State, error) {
 	log.Debugf("Getting current state...")
 	if err := d.validateVMRef(); err != nil {
-		return state.None, err
+		return state.Error, err
 	}
 	virState, _, err := d.vm.GetState()
 	if err != nil {
-		return state.None, err
+		return state.Error, err
 	}
 	switch virState {
-	case libvirt.DOMAIN_NOSTATE:
-		return state.None, nil
 	case libvirt.DOMAIN_RUNNING:
 		return state.Running, nil
-	case libvirt.DOMAIN_BLOCKED:
-		// TODO - Not really correct, but does it matter?
-		return state.Error, nil
 	case libvirt.DOMAIN_PAUSED:
 		return state.Paused, nil
 	case libvirt.DOMAIN_SHUTDOWN:
 		return state.Stopped, nil
-	case libvirt.DOMAIN_CRASHED:
-		return state.Error, nil
 	case libvirt.DOMAIN_PMSUSPENDED:
 		return state.Saved, nil
 	case libvirt.DOMAIN_SHUTOFF:
 		return state.Stopped, nil
 	}
-	return state.None, nil
+	return state.Error, fmt.Errorf("unexpected libvirt status %d", virState)
 }
 
 func (d *Driver) validateVMRef() error {


### PR DESCRIPTION
None is almost always an alias of Error. Also, it is a real mystery to understand why a status is None. Let's remove it. 

Also treat unexpected libvirt statuses as errors like pause, pmsuspended, etc.
crc doesn't nothing with state.Saved, Paused, etc. It is better to remove it and show an error. 