### PR TITLE
.crc-exist file is managed by libmachine code itself.

### DIFF
--- a/pkg/libvirt/libvirt.go
+++ b/pkg/libvirt/libvirt.go
@@ -316,8 +316,6 @@ func (d *Driver) Create() error {
 	}
 	d.vm = vm
 	d.vmLoaded = true
-	log.Debugf("Adding the file: %s", filepath.Join(d.ResolveStorePath("."), fmt.Sprintf(".%s-exist", d.MachineName)))
-	_, _ = os.OpenFile(filepath.Join(d.ResolveStorePath("."), fmt.Sprintf(".%s-exist", d.MachineName)), os.O_RDONLY|os.O_CREATE, 0666)
 
 	_, err = d.resizeDiskImageIfNeeded(d.DiskCapacity)
 	if err != nil {


### PR DESCRIPTION
For other drivers, the file is created by libmachine with
api.SetExists(). Libvirt driver is the only one to do that.

---
 I believe we forgot to remove this code when pushing up .crc-exists in libmachine.

It implies that `crc status` returns `Machine does not exist. Use 'crc start' to create it ` until the machine has an IP. 
Before, `crc status` was able to report a status right after the VM is defined. 

It is now like the others OSes.