### PR TITLE
copyFile: Don't ignore Close() errors on writable file

### DIFF
--- a/pkg/libvirt/copy.go
+++ b/pkg/libvirt/copy.go
@@ -29,5 +29,9 @@ func copyFile(src, dst string) error {
 		return err
 	}
 
-	return os.Chmod(dst, fi.Mode())
+	if err = os.Chmod(dst, fi.Mode()); err != nil {
+		return err
+	}
+
+	return out.Close()
 }


### PR DESCRIPTION
This follows the advice from
https://www.joeshaw.org/dont-defer-close-on-writable-files/
Write() is not fully synchronous, so some errors writing the file may
only be reported at Close() time.