### PR TITLE
spec: Use %goname

### DIFF
--- a/crc-driver-libvirt.spec.in
+++ b/crc-driver-libvirt.spec.in
@@ -1,5 +1,6 @@
 # https://github.com/code-ready/machine-driver-libvirt
 %global goipath         github.com/code-ready/machine-driver-libvirt
+%global goname          crc-driver-libvirt
 Version:                __VERSION__
 
 %gometa


### PR DESCRIPTION
This allows to name the generated RPMs `crc-driver-libvirt*` rather than
`golang-github-code-ready-machine-driver-libvirt*`