### PR TITLE
CI: Switch to centos-stream base image

### DIFF
--- a/Containerfile.centos8
+++ b/Containerfile.centos8
@@ -1,4 +1,4 @@
-FROM centos:8
+FROM quay.io/centos/centos:stream8
 
 MAINTAINER CodeReady Containers
 

--- a/Containerfile.rpmbuild
+++ b/Containerfile.rpmbuild
@@ -1,4 +1,4 @@
-FROM registry.centos.org/centos
+FROM quay.io/centos/centos:stream8
 WORKDIR $APP_ROOT/src
 RUN yum -y install git-core rpm-build dnf-plugins-core 'dnf-command(builddep)'
 COPY . .


### PR DESCRIPTION
Container file for centos8 is using `centos:8` which is causing issue
on the CI.

```
 ---> Running in 0ecead35430d
CentOS Linux 8 - AppStream                      108  B/s |  38  B     00:00
Error: Failed to download metadata for repo 'appstream': Cannot prepare internal mirrorlist: No URLs in mirrorlist
The command '/bin/sh -c yum install -y libvirt-devel curl git gcc make golang diffutils' returned a non-zero code: 1
make: *** [Makefile:22: crc-driver-libvirt-centos8] Error 1
```

This patch update it to `quay.io/centos/centos:stream8` which
doesn't seem to have this issue.