### PR TITLE
virtiofs: Don't check Filesystem support if it is nil

### DIFF
--- a/pkg/libvirt/domain.go
+++ b/pkg/libvirt/domain.go
@@ -177,6 +177,10 @@ func virtiofsSupported(conn *libvirt.Connect) error {
 		return fmt.Errorf("Error parsing libvirt domain capabilities: %w", err)
 	}
 
+	if caps.Devices.FileSystem == nil {
+		return drivers.ErrNotSupported
+	}
+
 	if caps.Devices.FileSystem.Supported != "yes" {
 		return drivers.ErrNotSupported
 	}


### PR DESCRIPTION
Domain capabilities for older version of libvirt doesn't contain
filesystem entry. Using this PR we first check if there is filesystem
entry on capabilities then only check for supported driverTypes.

Our CI have older version of libvirt and it should fix following error
```
Error creating machine: Error in driver during machine creation: Panic in the driver: runtime error: invalid memory address or nil pointer dereference
goroutine 15 [running]:
runtime/debug.Stack()
	/usr/lib/golang/src/runtime/debug/stack.go:24 +0x65
github.com/code-ready/machine/libmachine/drivers/rpc.(*StandardStack).Stack(0xc000026000?)
	/go/src/github.com/code-ready/machine-driver-libvirt/vendor/github.com/code-ready/machine/libmachine/drivers/rpc/server_driver.go:20 +0x17
github.com/code-ready/machine/libmachine/drivers/rpc.trapPanic(0xc0002bb740)
	/go/src/github.com/code-ready/machine-driver-libvirt/vendor/github.com/code-ready/machine/libmachine/drivers/rpc/server_driver.go:72 +0x63
panic({0x886dc0, 0xe18ba0})
	/usr/lib/golang/src/runtime/panic.go:838 +0x207
github.com/code-ready/machine-driver-libvirt/pkg/libvirt.virtiofsSupported(0xc0000720c0?)
	/go/src/github.com/code-ready/machine-driver-libvirt/pkg/libvirt/domain.go:187 +0x1c5
github.com/code-ready/machine-driver-libvirt/pkg/libvirt.domainXML(0xc0000720c0, {0x903e89, 0x3})
	/go/src/github.com/code-ready/machine-driver-libvirt/pkg/libvirt/domain.go:123 +0x9ef
github.com/code-ready/machine-driver-libvirt/pkg/libvirt.(*Driver).Create(0xc0000720c0)
	/go/src/github.com/code-ready/machine-driver-libvirt/pkg/libvirt/libvirt.go:316 +0x95
github.com/code-ready/machine/libmachine/drivers/rpc.(*RPCServerDriver).Create(0x2?, 0xc000018b10?, 0x1?)
	/go/src/github.com/code-ready/machine-driver-libvirt/vendor/github.com/code-ready/machine/libmachine/drivers/rpc/server_driver.go:83 +0x67
reflect.Value.call({0xc0000801e0?, 0xc000010178?, 0x13?}, {0x9040ff, 0x4}, {0xc000068ef8, 0x3, 0x3?})
	/usr/lib/golang/src/reflect/value.go:556 +0x845
reflect.Value.Call({0xc0000801e0?, 0xc000010178?, 0x3?}, {0xc0000506f8, 0x3, 0x3})
	/usr/lib/golang/src/reflect/value.go:339 +0xbf
net/rpc.(*service).call(0xc00007e180, 0xc00008a1e0?, 0xc000050750?, 0xc0000181b0, 0xc000024b00, 0xc00008a1e0?, {0x857c00?, 0xe8e1c8?, 0x78e4c6?}, {0x857c00, ...}, ...)
	/usr/lib/golang/src/net/rpc/server.go:381 +0x226
created by net/rpc.(*Server).ServeCodec
	/usr/lib/golang/src/net/rpc/server.go:478 +0x3fe
```