### PR TITLE
remove setting StoragePool for the driver in constructor

### DIFF
--- a/pkg/libvirt/libvirt.go
+++ b/pkg/libvirt/libvirt.go
@@ -544,8 +544,7 @@ func NewDriver(hostName, storePath string) drivers.Driver {
 					StorePath:   storePath,
 				},
 			},
-			Network:     DefaultNetwork,
-			StoragePool: DefaultPool,
+			Network: DefaultNetwork,
 		},
 	}
 }


### PR DESCRIPTION
if this is not set it'll use the MachineName as the pool name which will be usefull in the scenario when we want to  create more then one VM

if needed this can also be set from CRC when initializing the driver struct

related to https://github.com/crc-org/crc/pull/3750