### PR TITLE
Update go version to 1.21

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -17,4 +17,4 @@ require (
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )
 
-go 1.19
+go 1.21

--- a/tools/go.mod
+++ b/tools/go.mod
@@ -1,6 +1,6 @@
 module github.com/crc-org/crc/tools
 
-go 1.19
+go 1.21
 
 require (
 	github.com/cfergeau/gomod2rpmdeps v0.0.0-20210223144124-2042c4850ca8


### PR DESCRIPTION
Since 1.18 is already EOL and all our tooling migrated to go-1.21

- https://endoflife.date/go