### PR TITLE
Update domain template for arm64 use case

### DIFF
--- a/pkg/libvirt/domain.go
+++ b/pkg/libvirt/domain.go
@@ -31,6 +31,7 @@ func domainXML(d *Driver, machineType string) (string, error) {
 			Mode: "host-passthrough",
 		},
 		OS: &libvirtxml.DomainOS{
+			Firmware: "efi",
 			Type: &libvirtxml.DomainOSType{
 				Type: "hvm",
 			},

--- a/pkg/libvirt/domain.go
+++ b/pkg/libvirt/domain.go
@@ -29,13 +29,6 @@ func domainXML(d *Driver, machineType string) (string, error) {
 		},
 		CPU: &libvirtxml.DomainCPU{
 			Mode: "host-passthrough",
-			// https://bugzilla.redhat.com/show_bug.cgi?id=1806532
-			Features: []libvirtxml.DomainCPUFeature{
-				{
-					Policy: "disable",
-					Name:   "rdrand",
-				},
-			},
 		},
 		OS: &libvirtxml.DomainOS{
 			Type: &libvirtxml.DomainOSType{

--- a/pkg/libvirt/domain_test.go
+++ b/pkg/libvirt/domain_test.go
@@ -42,9 +42,7 @@ func TestTemplating(t *testing.T) {
     <acpi></acpi>
     <apic></apic>
   </features>
-  <cpu mode="host-passthrough">
-    <feature policy="disable" name="rdrand"></feature>
-  </cpu>
+  <cpu mode="host-passthrough"></cpu>
   <clock offset="utc"></clock>
   <devices>
     <disk type="file" device="disk">

--- a/pkg/libvirt/domain_test.go
+++ b/pkg/libvirt/domain_test.go
@@ -32,7 +32,7 @@ func TestTemplating(t *testing.T) {
   <name>domain</name>
   <memory unit="MiB">4096</memory>
   <vcpu>4</vcpu>
-  <os>
+  <os firmware="efi">
     <type machine="q35">hvm</type>
     <boot dev="hd"></boot>
     <bootmenu enable="no"></bootmenu>
@@ -85,7 +85,7 @@ func TestVSockTemplating(t *testing.T) {
 	}, "")
 	assert.NoError(t, err)
 	assert.Regexp(t, `(?s)<devices>(.*?)<vsock model="virtio">\s*<cid auto="yes">\s*</cid>\s*</vsock>(.*?)</devices>`, xml)
-	assert.Regexp(t, `(?s)<os>(.*?)<type>hvm</type>(.*?)</os>`, xml)
+	assert.Regexp(t, `(?s)<os firmware="efi">(.*?)<type>hvm</type>(.*?)</os>`, xml)
 }
 
 func TestNetworkTemplating(t *testing.T) {

--- a/pkg/libvirt/libvirt.go
+++ b/pkg/libvirt/libvirt.go
@@ -448,7 +448,7 @@ func (d *Driver) Remove() error {
 	//       could take a snapshot.  If you do, then Undefine
 	//       will fail unless we nuke the snapshots first
 	_ = d.vm.Destroy() // Ignore errors
-	return d.vm.Undefine()
+	return d.vm.UndefineFlags(libvirt.DOMAIN_UNDEFINE_NVRAM)
 }
 
 func (d *Driver) Restart() error {


### PR DESCRIPTION
With the following patches I can manage crc VM on arm64 and amd64 linux machines. I also need to add CI to build arm64 bits but in separate PR.