### PR TITLE
use almalinux minimal-8 image to replace the centos8 image

### DIFF
--- a/Containerfile.almalinux8
+++ b/Containerfile.almalinux8
@@ -1,8 +1,8 @@
-FROM quay.io/centos/centos:stream8
+FROM quay.io/almalinuxorg/8-minimal:8
 
 MAINTAINER CRC team
 
-RUN yum install -y libvirt-devel curl git gcc make golang diffutils
+RUN microdnf install -y libvirt-devel curl git gcc make golang diffutils
 
 COPY . /go/src/github.com/crc-org/machine-driver-libvirt
 WORKDIR /go/src/github.com/crc-org/machine-driver-libvirt

--- a/Containerfile.rpmbuild
+++ b/Containerfile.rpmbuild
@@ -1,4 +1,4 @@
-FROM quay.io/centos/centos:stream8
+FROM quay.io/almalinuxorg/8-base:8
 WORKDIR $APP_ROOT/src
 RUN yum -y install git-core rpm-build dnf-plugins-core 'dnf-command(builddep)'
 COPY . .

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ DESCRIBE=$(shell git describe --tags)
 VERSION=$(shell grep DriverVersion pkg/libvirt/constants.go | awk '{ print $$3 }' | tr -d \")
 CONTAINER_RUNTIME ?= podman
 
-TARGETS=$(addprefix $(CMD)-, centos8)
+TARGETS=$(addprefix $(CMD)-, almalinux8)
 
 build: $(TARGETS)
 


### PR DESCRIPTION
since centos8 has reached EOL the Container image cannot install
packages and hence the build fails