### PR TITLE
domain: Disable secure boot feature

### DIFF
--- a/pkg/libvirt/domain.go
+++ b/pkg/libvirt/domain.go
@@ -32,6 +32,14 @@ func domainXML(d *Driver, machineType string) (string, error) {
 		},
 		OS: &libvirtxml.DomainOS{
 			Firmware: "efi",
+			FirmwareInfo: &libvirtxml.DomainOSFirmwareInfo{
+				Features: []libvirtxml.DomainOSFirmwareFeature{
+					{
+						Name:    "secure-boot",
+						Enabled: "no",
+					},
+				},
+			},
 			Type: &libvirtxml.DomainOSType{
 				Type: "hvm",
 			},

--- a/pkg/libvirt/domain_test.go
+++ b/pkg/libvirt/domain_test.go
@@ -34,6 +34,9 @@ func TestTemplating(t *testing.T) {
   <vcpu>4</vcpu>
   <os firmware="efi">
     <type machine="q35">hvm</type>
+    <firmware>
+      <feature enabled="no" name="secure-boot"></feature>
+    </firmware>
     <boot dev="hd"></boot>
     <bootmenu enable="no"></bootmenu>
   </os>


### PR DESCRIPTION
During debugging of OKD bundle test on github runner, found out that `AMD EPYC 7763 64-Core Processor` which runner uses for VM environment doesn't support secure boot and vm creation failed with following error.

With this PR we are explictly disable the secure boot as feature when `uefi` is enabled.

```
-device vhost-vsock-pci,id=vsock0,guest-cid=3,vhostfd=29,bus=pci.5,addr=0x0 \
-msg timestamp=on
ESC[2JESC[01;01HESC[=3hESC[2JESC[01;01HBdsDxe: loading Boot0001 "UEFI Misc Device" from PciRoot(0x0)/Pci(0x2,0x2)/Pci(0x0,0x0)
BdsDxe: starting Boot0001 "UEFI Misc Device" from PciRoot(0x0)/Pci(0x2,0x2)/Pci(0x0,0x0)
EFI stub: UEFI Secure Boot is enabled.
KVM: entry failed, hardware error 0xffffffff
EAX=00000000 EBX=a7e03da8 ECX=00000000 EDX=000000b2
ESI=ff98a000 EDI=00000058 EBP=0000000c ESP=a7e03d18
EIP=00008000 EFL=00000002 [-------] CPL=0 II=0 A20=1 SMM=1 HLT=0
ES =0000 00000000 ffffffff 00809300
CS =c200 7ffc2000 ffffffff 00809300
SS =0000 00000000 ffffffff 00809300
DS =0000 00000000 ffffffff 00809300
FS =0000 00000000 ffffffff 00809300
GS =0000 00000000 ffffffff 00809300
LDT=0000 00000000 00000000 00000000
TR =0040 00003000 00004087 00008b00
:
```

also
https://github.com/dockur/windows/issues/231#issuecomment-1993795069 suggest that it can also happen with old intel hardware and I tried to disable the `tdp_mmu` on this AMD hardware but that didn't fix it.

commands to used to disable `tdp_mmu`
```
$ sudo modprobe -r kvm_amd
$ sudo modprobe -r kvm
$ sudo modprobe kvm tdp_mmu=0
$ sudo modprobe  kvm
$ sudo modprobe kvm_amd
$ sudo cat /sys/module/kvm/parameters/tdp_mmu
N
```